### PR TITLE
Feature/nlp feature flag update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,18 @@ environment variables, or with a link to a configuration guide.
 | AWS_SERVICE                  | "es"                      | The AWS service that the AWS SDK signing mechanism needs to sign a request
 | AWS_SIGNER                   | false                     | The AWS signer flag will determine if requests to Elasticsearch contain round tripper for signing requests
 | AWS_TLS_INSECURE_SKIP_VERIFY | false                     | This should never be set to true, as it disables SSL certificate verification. Used only for development
+| -------------------          | -------------------       | -----------------------------------
 | BIND_ADDR                    | :23900                    | The host and port to bind to
 | ELASTIC_SEARCH_URL           | "<http://localhost:11200>"| Http url of the ElasticSearch server
+| -------------------          | -------------------       | -----------------------------------
+| NLP_BERLIN_API_ENDPOINT      | "/v1/berlin/search"       | Http url of the Berlin server
 | NLP_BERLIN_API_URL	         | "http://localhost:28900"  | Http url of the Berlin server
+| NLP_CATEGORY_API_ENDPOINT    | "/categories"             | Http url of the Category server
 | NLP_CATEGORY_API_URL	       | "http://localhost:28800"  | Http url of the Category server
+| NlpToggle           	       | "true"                    | Toggles NLP querying on/off
+| NLP_SCRUBBER_API_ENDPOINT    | "/v1/scrubber"            | Http url of the Scrubber server
 | NLP_SCRUBBER_API_URL	       | "http://localhost:28700"  | Http url of the Scrubber server
+| -------------------          | -------------------       | -----------------------------------
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                        | The graceful shutdown timeout in seconds (`time.Duration` format)
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
 | HEALTHCHECK_INTERVAL         | 30s                       | Time between self-healthchecks (`time.Duration` format)

--- a/api/search.go
+++ b/api/search.go
@@ -457,7 +457,7 @@ func LegacySearchHandlerFunc(validator QueryParamValidator, queryBuilder QueryBu
 }
 
 func getNLPCritiria(ctx context.Context, params url.Values, nlpConfig config.NLP, queryBuilder QueryBuilder, nlpCLI *nlp.Client) *query.NlpCriteria {
-	if params.Get("c") == "1" {
+	if nlpConfig.NlpToggle {
 		nlpSettings := query.NlpSettings{}
 
 		log.Info(ctx, "Employing advanced natural language processing techniques to optimize Elasticsearch querying for enhanced result relevance.")

--- a/config/config.go
+++ b/config/config.go
@@ -29,13 +29,14 @@ type AWS struct {
 }
 
 type NLP struct {
-	NlpHubSettings      string `envconfig:"NLP_HUB_SETTINGS"`
 	BerlinAPIEndpoint   string `envconfig:"NLP_BERLIN_API_ENDPOINT"`
 	BerlinAPIURL        string `envconfig:"NLP_BERLIN_API_URL"`
-	ScrubberAPIEndpoint string `envconfig:"NLP_SCRUBBER_API_ENDPOINT"`
-	ScrubberAPIURL      string `envconfig:"NLP_SCRUBBER_API_URL"`
 	CategoryAPIEndpoint string `envconfig:"NLP_CATEGORY_API_ENDPOINT"`
 	CategoryAPIURL      string `envconfig:"NLP_CATEGORY_API_URL"`
+	NlpHubSettings      string `envconfig:"NLP_HUB_SETTINGS"`
+	NlpToggle           bool   `envconfig:"NLP_TOGGLE"`
+	ScrubberAPIEndpoint string `envconfig:"NLP_SCRUBBER_API_ENDPOINT"`
+	ScrubberAPIURL      string `envconfig:"NLP_SCRUBBER_API_URL"`
 }
 
 var cfg *Config
@@ -56,11 +57,12 @@ func Get() (*Config, error) {
 	}
 
 	cfg.NLP = NLP{
-		NlpHubSettings:      "{\"categoryWeighting\": 10000000000000000000000000000.0, \"categoryLimit\": 100, \"defaultState\": \"gb\"}",
 		BerlinAPIEndpoint:   "/v1/berlin/search",
 		BerlinAPIURL:        "http://localhost:28900",
 		CategoryAPIEndpoint: "/categories",
 		CategoryAPIURL:      "http://localhost:28800",
+		NlpHubSettings:      "{\"categoryWeighting\": 10000000000000000000000000000.0, \"categoryLimit\": 100, \"defaultState\": \"gb\"}",
+		NlpToggle:           true,
 		ScrubberAPIEndpoint: "/v1/scrubber",
 		ScrubberAPIURL:      "http://localhost:28700",
 	}


### PR DESCRIPTION
### What

As per Lindens request I've removed the C flag as a query parameter and added it as a env variable
I've also updated the docs with new env variables

### How to review

add a global env called NLP_TOGGLE run dp-search-api and check if it makes calls to nlp apis

### Who can review

Andrea
